### PR TITLE
feat: disable Style Arrays and NumericLiterals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,12 @@ Style/ClassAndModuleChildren:
 
 RSpec/DescribedClass:
   Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,12 +23,13 @@ Style/ClassAndModuleChildren:
 
 RSpec/DescribedClass:
   Enabled: false
-
+  
 Style/WordArray:
-  Enabled: false
+  EnforcedStyle: brackets
 
 Style/SymbolArray:
-  Enabled: false
+  EnforcedStyle: brackets
 
 Style/NumericLiterals:
   Enabled: false
+  


### PR DESCRIPTION
I don't like ``` %w[foo bar]``` this is better ``` ['foo', 'bar'] ```

also `30_000` looks  mathematically wrong 